### PR TITLE
Several improvements

### DIFF
--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -1,6 +1,6 @@
-import { findlib } from "./util.ts";
+import { findLib } from "./util.ts";
 
-const lib = Deno.env.get("DENO_PYTHON_PATH") ?? await findlib();
+const lib = Deno.env.get("DENO_PYTHON_PATH") ?? await findLib();
 
 try {
   // deno-lint-ignore no-inner-declarations no-var
@@ -102,6 +102,11 @@ try {
 
     PyObject_SetAttrString: {
       parameters: ["pointer", "pointer", "pointer"],
+      result: "i32",
+    },
+
+    PyObject_HasAttrString: {
+      parameters: ["pointer", "pointer"],
       result: "i32",
     },
 
@@ -331,6 +336,31 @@ try {
     },
 
     PyDict_GetItem: {
+      parameters: ["pointer", "pointer"],
+      result: "pointer",
+    },
+
+    PySet_New: {
+      parameters: ["pointer"],
+      result: "pointer",
+    },
+
+    PySet_Add: {
+      parameters: ["pointer", "pointer"],
+      result: "i32",
+    },
+
+    PyImport_ExecCodeModule: {
+      parameters: ["pointer", "pointer"],
+      result: "pointer",
+    },
+
+    PyObject_IsInstance: {
+      parameters: ["pointer", "pointer"],
+      result: "i32",
+    },
+
+    PyDict_GetItemString: {
       parameters: ["pointer", "pointer"],
       result: "pointer",
     },

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -364,6 +364,16 @@ try {
       parameters: ["pointer", "pointer"],
       result: "pointer",
     },
+
+    PyTuple_Size: {
+      parameters: ["pointer"],
+      result: "i32",
+    },
+
+    PyTuple_GetItem: {
+      parameters: ["pointer", "i32"],
+      result: "pointer",
+    },
   }).symbols;
 } catch (e) {
   throw new Error(`Python library not found: ${(e as Error).message}`);

--- a/src/python.ts
+++ b/src/python.ts
@@ -426,6 +426,21 @@ export class PyObject {
   }
 
   /**
+   * Casts a Tuple Python object as JS Array value.
+   */
+  asTuple() {
+    const tuple = new Array<PythonConvertible>();
+    const length = py.PyTuple_Size(this.handle) as number;
+    for (let i = 0; i < length; i++) {
+      tuple.push(
+        new PyObject(py.PyTuple_GetItem(this.handle, i) as Deno.UnsafePointer)
+          .valueOf(),
+      );
+    }
+    return tuple;
+  }
+
+  /**
    * Tries to guess the value of the Python object.
    * Only primitives are casted as JS value type, otherwise returns
    * a proxy to Python object.
@@ -449,6 +464,8 @@ export class PyObject {
       return this.asDict();
     } else if (type === python.set[ProxiedPyObject].handle.value) {
       return this.asSet();
+    } else if (type === python.tuple[ProxiedPyObject].handle.value) {
+      return this.asTuple();
     } else {
       return this.proxy;
     }
@@ -557,6 +574,7 @@ export class Python {
   list: any;
   dict: any;
   set: any;
+  tuple: any;
   None: any;
 
   constructor() {
@@ -571,6 +589,7 @@ export class Python {
     this.None = this.builtins.None;
     this.bool = this.builtins.bool;
     this.set = this.builtins.set;
+    this.tuple = this.builtins.tuple;
   }
 
   /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -67,7 +67,7 @@ async function search(path: string): Promise<string[]> {
   return found;
 }
 
-async function findlibs(): Promise<string[]> {
+async function findLibs(): Promise<string[]> {
   const libs: string[] = [];
 
   if (Deno.build.os === "windows") {
@@ -125,8 +125,8 @@ async function findlibs(): Promise<string[]> {
   return [...new Set(libs)];
 }
 
-export async function findlib(): Promise<string> {
-  const candidates = await findlibs();
+export async function findLib(): Promise<string> {
+  const candidates = await findLibs();
 
   for (const [major, minor] of versions) {
     const version = Deno.build.os === "windows"

--- a/test/test.ts
+++ b/test/test.ts
@@ -43,6 +43,11 @@ Deno.test("types", async (t) => {
     value = PyObject.from(new Set([1, 2, 3]));
     assertEquals(value.valueOf(), new Set([1, 2, 3]));
   });
+
+  await t.step("tuple", () => {
+    const value = python.tuple([1, 2, 3]);
+    assertEquals(value.valueOf(), [1, 2, 3]);
+  });
 });
 
 Deno.test("object", async (t) => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals } from "./deps.ts";
-import { PyObject, python } from "../mod.ts";
+import { NamedArgument, PyObject, python } from "../mod.ts";
 
 Deno.test("python version", () => {
   const { version } = python.import("sys");
@@ -97,4 +97,12 @@ class Person:
     list[0] = 42;
     assertEquals(list[0].valueOf(), 42);
   });
+});
+
+Deno.test("named argument", () => {
+  assertEquals(
+    python.str("Hello, {name}!").format(new NamedArgument("name", "world"))
+      .valueOf(),
+    "Hello, world!",
+  );
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals } from "./deps.ts";
-import { python } from "../mod.ts";
+import { PyObject, python } from "../mod.ts";
 
 Deno.test("python version", () => {
   const { version } = python.import("sys");
@@ -35,5 +35,66 @@ Deno.test("types", async (t) => {
   await t.step("dict", () => {
     const value = python.dict({ a: 1, b: 2 });
     assertEquals(value.valueOf(), new Map([["a", 1], ["b", 2]]));
+  });
+
+  await t.step("set", () => {
+    let value = python.set([1, 2, 3]);
+    assertEquals(value.valueOf(), new Set([1, 2, 3]));
+    value = PyObject.from(new Set([1, 2, 3]));
+    assertEquals(value.valueOf(), new Set([1, 2, 3]));
+  });
+});
+
+Deno.test("object", async (t) => {
+  const { Person } = python.runModule(`
+class Person:
+  def __init__(self, name):
+    self.name = name
+`);
+  const person = new Person("John");
+
+  await t.step("get attr", () => {
+    assertEquals(person.name.valueOf(), "John");
+  });
+
+  await t.step("set attr", () => {
+    person.name = "Jane";
+    assertEquals(person.name.valueOf(), "Jane");
+  });
+
+  await t.step("has attr", () => {
+    assert("name" in person);
+  });
+
+  await t.step("dict item", () => {
+    const dict = python.dict({ prop: "value" });
+    assertEquals(dict.prop.valueOf(), "value");
+  });
+
+  await t.step("dict set item", () => {
+    const dict = python.dict({ prop: "value" });
+    dict.prop = "new value";
+    assertEquals(dict.prop.valueOf(), "new value");
+  });
+
+  await t.step("dict has item", () => {
+    const dict = python.dict({ prop: "value" });
+    assert("prop" in dict);
+  });
+
+  await t.step("dict not has item", () => {
+    const dict = python.dict({ prop: "value" });
+    assert(!("prop2" in dict));
+  });
+
+  await t.step("list index", () => {
+    const list = python.list([1, 2, 3]);
+    assertEquals(list[0].valueOf(), 1);
+  });
+
+  await t.step("list set index", () => {
+    const list = python.list([1, 2, 3]);
+    list[0] = 42;
+    assertEquals(list[0].valueOf(), 42);
   });
 });


### PR DESCRIPTION
- fix: type of `PythonConvertible`. Now it's array, map, set, etc. types reference to itself instead of only primitives.
- feat: support Sets
- feat: support accessing/setting list indexes using JS `list[index]`
- feat: support setting attributes
- feat: support `in` operator by implementing `has` proxy accessor
- feat: support accessing/setting dict items using JS `dict[key]`
- feat: support importing module from code string
- feat: add `isInstance` on `PyObject`
- feat: support Named Arguments in function calls
- feat: support Tuples
- feat: support accessing tuple indexes using JS `tuple[index]`
- docs: explain many things