### PR TITLE
fix: add `Symbol.iterator` to Proxied PyObject

### DIFF
--- a/src/python.ts
+++ b/src/python.ts
@@ -163,6 +163,14 @@ export class PyObject {
       value: () => this.toString(),
     });
 
+    Object.defineProperty(object, Symbol.iterator, {
+      value: function* () {
+        for (const v of scope) {
+          yield v.proxy;
+        }
+      },
+    });
+
     Object.defineProperty(object, ProxiedPyObject, {
       value: this,
       enumerable: false,

--- a/src/python.ts
+++ b/src/python.ts
@@ -164,11 +164,7 @@ export class PyObject {
     });
 
     Object.defineProperty(object, Symbol.iterator, {
-      value: function* () {
-        for (const v of scope) {
-          yield v.proxy;
-        }
-      },
+      value: () => this[Symbol.iterator](),
     });
 
     Object.defineProperty(object, ProxiedPyObject, {

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.119.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.125.0/testing/asserts.ts";

--- a/test/test.ts
+++ b/test/test.ts
@@ -105,6 +105,16 @@ class Person:
     list[0] = 42;
     assertEquals(list[0].valueOf(), 42);
   });
+
+  await t.step("list iter", () => {
+    const array = [1, 2, 3];
+    const list = python.list(array);
+    let i = 0;
+    for (const v of list) {
+      assertEquals(v.valueOf(), array[i]);
+      i++;
+    }
+  });
 });
 
 Deno.test("named argument", () => {


### PR DESCRIPTION
closes #10 