### PR TITLE
feat: add array slicing (#18)

### DIFF
--- a/src/python.ts
+++ b/src/python.ts
@@ -1,6 +1,6 @@
 // deno-lint-ignore-file no-explicit-any no-fallthrough
 import { py } from "./ffi.ts";
-import { cstr } from "./util.ts";
+import { cstr, SliceItemRegExp } from "./util.ts";
 
 /**
  * Symbol used on proxied Python objects to point to the original PyObject object.
@@ -215,6 +215,17 @@ export class PyObject {
           }
         }
 
+        if (typeof name === "string" && isSlice(name)) {
+          const slice = toSlice(name);
+          const item = py.PyObject_GetItem(
+            this.handle,
+            slice.handle,
+          ) as Deno.UnsafePointer;
+          if (item.value !== 0n) {
+            return new PyObject(item).proxy;
+          }
+        }
+
         // Don't wanna throw errors when accessing properties.
         const attr = this.maybeGetAttr(String(name))?.proxy;
 
@@ -252,6 +263,14 @@ export class PyObject {
           py.PyList_SetItem(
             this.handle,
             Number(name),
+            PyObject.from(value).handle,
+          );
+          return true;
+        } else if (isSlice(name)) {
+          const slice = toSlice(name);
+          py.PyObject_SetItem(
+            this.handle,
+            slice.handle,
             PyObject.from(value).handle,
           );
           return true;
@@ -783,3 +802,47 @@ export class Python {
  * this object, such as `str`, `int`, `tuple`, etc.
  */
 export const python = new Python();
+
+/**
+ * Returns true if the value can be converted into a Python slice or
+ * slice tuple.
+ */
+function isSlice(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  if (!value.includes(":")) return false;
+  return value
+    .split(",")
+    .map((item) => SliceItemRegExp.test(item) || /^\s*-?\d+\s*$/.test(item))
+    .reduce((a, b) => a && b, true);
+}
+
+/**
+ * Returns a PyObject that is either a slice or a tuple of slices.
+ */
+function toSlice(sliceList: string): PyObject {
+  if (sliceList.includes(",")) {
+    const pySlicesHandle = sliceList.split(",")
+      .map(toSlice)
+      .map((pyObject) => pyObject.handle);
+    const pyTupleHandle = (py as any).PyTuple_Pack(
+      pySlicesHandle.length,
+      ...pySlicesHandle,
+    );
+    return new PyObject(pyTupleHandle);
+  } else if (/^\s*-?\d+\s*$/.test(sliceList)) {
+    return PyObject.from(parseInt(sliceList));
+  } else {
+    const [start, stop, step] = sliceList
+      .split(":")
+      .map((
+        bound,
+      ) => (/^\s*-?\d+\s*$/.test(bound) ? parseInt(bound) : undefined));
+
+    const pySliceHandle = py.PySlice_New(
+      PyObject.from(start).handle,
+      PyObject.from(stop).handle,
+      PyObject.from(step).handle,
+    );
+    return new PyObject(pySliceHandle);
+  }
+}

--- a/src/python.ts
+++ b/src/python.ts
@@ -365,9 +365,8 @@ export class PyObject {
         } else {
           const dict = py.PyDict_New() as Deno.UnsafePointer;
           for (
-            const [key, value] of (v instanceof Map
-              ? v.entries()
-              : Object.entries(v))
+            const [key, value]
+              of (v instanceof Map ? v.entries() : Object.entries(v))
           ) {
             const keyObj = PyObject.from(key);
             const valueObj = PyObject.from(value);

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -368,4 +368,10 @@ export const SYMBOLS = {
     parameters: ["pointer", "i32"],
     result: "pointer",
   },
+
+  PyTuple_Pack: {
+    // TODO: This function should have variable length arguments
+    parameters: ["i32", "pointer", "pointer"],
+    result: "pointer",
+  },
 } as const;

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -370,8 +370,6 @@ export const SYMBOLS = {
   },
 
   PyTuple_Pack: {
-    // TODO: This function should have variable length arguments
-    parameters: ["i32", "pointer", "pointer"],
-    result: "pointer",
+    type: "pointer",
   },
 } as const;

--- a/src/util.ts
+++ b/src/util.ts
@@ -52,3 +52,11 @@ export function cstr(str: string): Uint8Array {
   encoder.encodeInto(str, buf);
   return buf;
 }
+
+/**
+ * Regular Expression used to test if a string is a `proper_slice`.
+ *
+ * Based on https://docs.python.org/3/reference/expressions.html#slicings
+ */
+export const SliceItemRegExp =
+  /^\s*(-?\d+)?\s*:\s*(-?\d+)?\s*(:\s*(-?\d+)?\s*)?$/;

--- a/test/test.ts
+++ b/test/test.ts
@@ -246,4 +246,20 @@ Deno.test("slice list", async (t) => {
       [7, 9],
     ]);
   });
+
+  await t.step("3d slicing", () => {
+    const a3 = np.array([[[10, 11, 12], [13, 14, 15], [16, 17, 18]], [
+      [20, 21, 22],
+      [23, 24, 25],
+      [26, 27, 28],
+    ], [[30, 31, 32], [33, 34, 35], [36, 37, 38]]]);
+
+    assertEquals(a3["0, :, 1"].tolist().valueOf(), [11, 14, 17]);
+  });
+
+  await t.step("ellipsis", () => {
+    const a4 = np.arange(16).reshape(2, 2, 2, 2);
+
+    assertEquals(a4["1, ..., 1"].tolist().valueOf(), [[9, 11], [13, 15]]);
+  });
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -48,7 +48,7 @@ Deno.test("types", async (t) => {
       new Map([
         ["a", 1],
         ["b", 2],
-      ])
+      ]),
     );
   });
 
@@ -136,7 +136,7 @@ Deno.test("named argument", async (t) => {
         .str("Hello, {name}!")
         .format(new NamedArgument("name", "world"))
         .valueOf(),
-      "Hello, world!"
+      "Hello, world!",
     );
   });
 
@@ -153,7 +153,7 @@ class Test:
       const d = python.dict({ a: 1, b: 2 });
       const v = t.test(1, 2, new NamedArgument("name", "vampire"), d);
       assertEquals(v.valueOf(), true);
-    }
+    },
   );
 });
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -43,7 +43,13 @@ Deno.test("types", async (t) => {
 
   await t.step("dict", () => {
     const value = python.dict({ a: 1, b: 2 });
-    assertEquals(value.valueOf(), new Map([["a", 1], ["b", 2]]));
+    assertEquals(
+      value.valueOf(),
+      new Map([
+        ["a", 1],
+        ["b", 2],
+      ])
+    );
   });
 
   await t.step("set", () => {
@@ -126,9 +132,11 @@ class Person:
 Deno.test("named argument", async (t) => {
   await t.step("single named argument", () => {
     assertEquals(
-      python.str("Hello, {name}!").format(new NamedArgument("name", "world"))
+      python
+        .str("Hello, {name}!")
+        .format(new NamedArgument("name", "world"))
         .valueOf(),
-      "Hello, world!",
+      "Hello, world!"
     );
   });
 
@@ -145,7 +153,7 @@ class Test:
       const d = python.dict({ a: 1, b: 2 });
       const v = t.test(1, 2, new NamedArgument("name", "vampire"), d);
       assertEquals(v.valueOf(), true);
-    },
+    }
   );
 });
 
@@ -170,4 +178,72 @@ Deno.test("custom proxy", () => {
 
   // Then, we use the wrapped proxy as if it were an original PyObject
   assertEquals(np.add(arr, 2).tolist().valueOf(), [3, 4, 5]);
+});
+
+Deno.test("slice", async (t) => {
+  await t.step("get", () => {
+    const list = python.list([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    assertEquals(list["1:"].valueOf(), [2, 3, 4, 5, 6, 7, 8, 9]);
+    assertEquals(list["1:2"].valueOf(), [2]);
+    assertEquals(list[":2"].valueOf(), [1, 2]);
+    assertEquals(list[":2:"].valueOf(), [1, 2]);
+    assertEquals(list["0:3:2"].valueOf(), [1, 3]);
+    assertEquals(list["-2:"].valueOf(), [8, 9]);
+    assertEquals(list["::2"].valueOf(), [1, 3, 5, 7, 9]);
+  });
+
+  await t.step("set", () => {
+    const np = python.import("numpy");
+    let list = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    list["1:"] = -5;
+    assertEquals(list.tolist().valueOf(), [1, -5, -5, -5, -5, -5, -5, -5, -5]);
+
+    list = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    list["1::3"] = -5;
+    assertEquals(list.tolist().valueOf(), [1, -5, 3, 4, -5, 6, 7, -5, 9]);
+
+    list = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    list["1:2:3"] = -5;
+    assertEquals(list.tolist().valueOf(), [1, -5, 3, 4, 5, 6, 7, 8, 9]);
+  });
+});
+
+Deno.test("slice list", async (t) => {
+  const np = python.import("numpy");
+
+  await t.step("get", () => {
+    const array = np.array([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ]);
+    assertEquals(array["0, :"].tolist().valueOf(), [1, 2, 3]);
+    assertEquals(array["1:, ::2"].tolist().valueOf(), [
+      [4, 6],
+      [7, 9],
+    ]);
+    assertEquals(array["1:, 0"].tolist().valueOf(), [4, 7]);
+  });
+
+  await t.step("set", () => {
+    const array = np.arange(15).reshape(3, 5);
+    array["1:, ::2"] = -99;
+    assertEquals(array.tolist().valueOf(), [
+      [0, 1, 2, 3, 4],
+      [-99, 6, -99, 8, -99],
+      [-99, 11, -99, 13, -99],
+    ]);
+  });
+
+  await t.step("whitespaces", () => {
+    const array = np.array([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ]);
+    assertEquals(array[" 1  :  , : :  2         "].tolist().valueOf(), [
+      [4, 6],
+      [7, 9],
+    ]);
+  });
 });


### PR DESCRIPTION
Adds array slicing. Closes #18

Supports `SetItem` and `GetItem` for both single slices and tuples of slices + numbers, which greatly increases the usability libraries like Numpy.

I had some issues with ``PyTuple_Pack``. [The Python C API](https://docs.python.org/3/c-api/tuple.html#c.PyTuple_Pack) states that the function can have _n + 1_ arguments. I don't know how to tell that to Deno. This limits array slicing to a single slice, or a tuple of 2 slices/numbers, but nothing more.

The syntax is as permissive as Python's and ignores white spaces between the different tokens.

I didn't add a slice class/object/function, because it doesn't make sense in JavaScript. Indexing an object/list can only be done using symbols and strings, but not objects. We probably could over-engineered something to get around this limitation, ~~using symbols and weakmaps~~ nevermind, you can't use symbols in weakmaps.