### PR TITLE
feat: support Deno v1.25

### DIFF
--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -25,7 +25,7 @@ export const SYMBOLS = {
   },
 
   PyImport_ImportModule: {
-    parameters: ["pointer"],
+    parameters: ["buffer"],
     result: "pointer",
   },
 
@@ -35,7 +35,7 @@ export const SYMBOLS = {
   },
 
   PyRun_SimpleString: {
-    parameters: ["pointer"],
+    parameters: ["buffer"],
     result: "i32",
   },
 
@@ -50,7 +50,7 @@ export const SYMBOLS = {
   },
 
   PyErr_Fetch: {
-    parameters: ["pointer", "pointer", "pointer"],
+    parameters: ["buffer", "buffer", "buffer"],
     result: "void",
   },
 
@@ -60,7 +60,7 @@ export const SYMBOLS = {
   },
 
   PyDict_SetItemString: {
-    parameters: ["pointer", "pointer", "pointer"],
+    parameters: ["pointer", "buffer", "pointer"],
     result: "i32",
   },
 
@@ -90,17 +90,17 @@ export const SYMBOLS = {
   },
 
   PyObject_GetAttrString: {
-    parameters: ["pointer", "pointer"],
+    parameters: ["pointer", "buffer"],
     result: "pointer",
   },
 
   PyObject_SetAttrString: {
-    parameters: ["pointer", "pointer", "pointer"],
+    parameters: ["pointer", "buffer", "pointer"],
     result: "i32",
   },
 
   PyObject_HasAttrString: {
-    parameters: ["pointer", "pointer"],
+    parameters: ["pointer", "buffer"],
     result: "i32",
   },
 
@@ -200,7 +200,7 @@ export const SYMBOLS = {
   },
 
   PyUnicode_DecodeUTF8: {
-    parameters: ["pointer", "i32", "pointer"],
+    parameters: ["buffer", "i32", "pointer"],
     result: "pointer",
   },
 
@@ -345,7 +345,7 @@ export const SYMBOLS = {
   },
 
   PyImport_ExecCodeModule: {
-    parameters: ["pointer", "pointer"],
+    parameters: ["buffer", "pointer"],
     result: "pointer",
   },
 
@@ -355,7 +355,7 @@ export const SYMBOLS = {
   },
 
   PyDict_GetItemString: {
-    parameters: ["pointer", "pointer"],
+    parameters: ["pointer", "buffer"],
     result: "pointer",
   },
 
@@ -374,7 +374,7 @@ export const SYMBOLS = {
   },
 
   PyCFunction_NewEx: {
-    parameters: ["pointer", "pointer", "pointer"],
+    parameters: ["buffer", "pointer", "pointer"],
     result: "pointer",
   },
 } as const;

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,7 +3,7 @@ export const decoder = new TextDecoder();
 
 const libDlDef = {
   dlopen: {
-    parameters: ["pointer", "i32"],
+    parameters: ["buffer", "i32"],
     result: "pointer",
   },
 } as const;
@@ -22,7 +22,7 @@ export function postSetup(lib: string) {
       gnu_get_libc_version: { parameters: [], result: "pointer" },
     });
     const ptrView = new Deno.UnsafePointerView(
-      libc.symbols.gnu_get_libc_version(),
+      BigInt(libc.symbols.gnu_get_libc_version()),
     );
     const glibcVersion = parseFloat(ptrView.getCString());
 
@@ -34,7 +34,7 @@ export function postSetup(lib: string) {
   } else if (Deno.build.os === "darwin") {
     libdl = Deno.dlopen(`libc.dylib`, {
       dlopen: {
-        parameters: ["pointer", "i32"],
+        parameters: ["buffer", "i32"],
         result: "pointer",
       },
     });


### PR DESCRIPTION
### These changes are not backward compatible with Deno version 1.24 and below!

Deno 1.25 released with [some changes to the FFI API.](https://deno.com/blog/v1.25#ffi-api-improvements)

### `buffer`

`pointer` no longer accept JavaScript `TypedArray`. Instead, we need to use type `buffer`.

### `Deno.PointerValue`

Deno now returns pointers as `number` or `bigint` according to their size. See [Deno CLI API](https://doc.deno.land/deno/unstable/~/Deno.PointerValue).

> On a 32 bit system all pointer values are plain numbers. On a 64 bit system pointer values are represented as numbers if the value is below `Number.MAX_SAFE_INTEGER`.

  This means that all pointers `0n` will now be `0`.

### Misc

Deno FFI functions now accept `number` as a pointer (altough their TypeScript type definitions still says they only support `bigint`)

---

These changes broke deno_python, so I fixed the code to support the latest version of Deno.

All tests should now pass on Deno 1.25.

I've been out of the loop for a while, so let me know if I missed anything 😄 
