### PR TITLE
fix: NULL pointer not being recognized

### DIFF
--- a/src/python.ts
+++ b/src/python.ts
@@ -194,6 +194,7 @@ export class PyObject {
    */
   get isNone() {
     return this.handle === 0 ||
+      this.handle === 0n ||
       this.handle === python.None[ProxiedPyObject].handle;
   }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -297,7 +297,7 @@ def call(cb):
 
 Deno.test("exceptions", async (t) => {
   await t.step("simple exception", () => {
-  assertThrows(() => python.runModule("1 / 0"));
+    assertThrows(() => python.runModule("1 / 0"));
   });
 
   await t.step("exception with traceback", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals } from "./deps.ts";
+import { assert, assertEquals, assertThrows } from "./deps.ts";
 import {
   kw,
   NamedArgument,
@@ -293,4 +293,16 @@ def call(cb):
     69,
   );
   cb.destroy();
+});
+
+Deno.test("exceptions", async (t) => {
+  await t.step("simple exception", () => {
+  assertThrows(() => python.runModule("1 / 0"));
+  });
+
+  await t.step("exception with traceback", () => {
+    const np = python.import("numpy");
+    const array = np.zeros([2, 3, 4]);
+    assertThrows(() => array.shape = [3, 6]);
+  });
 });


### PR DESCRIPTION
Small bug that slipped in #25 

The function `maybeThrowError()` saves errors codes in a array of `BigUInt64Array`. This automatically converts the pointers into `bigint`. I had modified the `get isNone()` function to only check for `number`. Some errors were ignored because of this.

I added 2 tests to check error handling.

Might be a good idea to create a util function `isZero()` that handles both `number` and `bigint`.