### PR TITLE
fix: deref garbage collected owned refs

### DIFF
--- a/src/python.ts
+++ b/src/python.ts
@@ -3,6 +3,8 @@
 import { py } from "./ffi.ts";
 import { cstr, SliceItemRegExp } from "./util.ts";
 
+const refregistry = new FinalizationRegistry(py.Py_DecRef);
+
 /**
  * Symbol used on proxied Python objects to point to the original PyObject object.
  * Can be used to implement PythonProxy and create your own proxies.
@@ -202,6 +204,7 @@ export class PyObject {
    */
   get owned(): PyObject {
     py.Py_IncRef(this.handle);
+    refregistry.register(this, this.handle);
     return this;
   }
 


### PR DESCRIPTION
I think we need to be careful with `borrowed refs` in addition to remembering to decrefing all rc'd refs.

> NOTE: This should be tested to make sure we don't have any memory leaks or use-after-free issues.
> This should be fine though and was tested with `--v8-flags=--allow-natives-syntax` and the natives function `%CollectGarbage(true)`