### PR TITLE
feat: set python exception if an error happens in a js callback

### DIFF
--- a/src/python.ts
+++ b/src/python.ts
@@ -184,7 +184,7 @@ export class Callback {
           // Set the Python exception (type and message)
           py.PyErr_SetString(errorTypeHandle, cErrorMessage);
 
-          return PyObject.from(null).handle;
+          return null;
         }
       },
     );

--- a/src/python.ts
+++ b/src/python.ts
@@ -154,13 +154,39 @@ export class Callback {
         args: Deno.PointerValue,
         kwargs: Deno.PointerValue,
       ) => {
-        return PyObject.from(callback(
-          kwargs === null ? {} : Object.fromEntries(
-            new PyObject(kwargs).asDict()
-              .entries(),
-          ),
-          ...(args === null ? [] : new PyObject(args).valueOf()),
-        )).handle;
+        let result: PythonConvertible;
+        // Prepare arguments for the JS callback
+        try {
+          // Prepare arguments for the JS callback
+          const jsKwargs = kwargs === null
+            ? {}
+            : Object.fromEntries(new PyObject(kwargs).asDict().entries());
+          const jsArgs = args === null ? [] : new PyObject(args).valueOf();
+
+          // Call the actual JS function
+          result = callback(jsKwargs, ...jsArgs);
+
+          // Convert the JS return value back to a Python object
+          return PyObject.from(result).handle;
+        } catch (e) {
+          // An error occurred in the JS callback.
+          // We need to set a Python exception and return NULL.
+
+          // Prepare the error message for Python
+          const errorMessage = e instanceof Error
+            ? `${e.name}: ${e.message}` // Include JS error type and message
+            : String(e); // Fallback for non-Error throws
+          const cErrorMessage = cstr(`JS Callback Error: ${errorMessage}`);
+
+          const errorTypeHandle =
+            python.builtins.RuntimeError[ProxiedPyObject].handle;
+          console.log(errorTypeHandle);
+
+          // Set the Python exception (type and message)
+          py.PyErr_SetString(errorTypeHandle, cErrorMessage);
+
+          return PyObject.from(null).handle;
+        }
       },
     );
   }

--- a/src/python.ts
+++ b/src/python.ts
@@ -180,7 +180,6 @@ export class Callback {
 
           const errorTypeHandle =
             python.builtins.RuntimeError[ProxiedPyObject].handle;
-          console.log(errorTypeHandle);
 
           // Set the Python exception (type and message)
           py.PyErr_SetString(errorTypeHandle, cErrorMessage);

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -39,6 +39,11 @@ export const SYMBOLS = {
     result: "void",
   },
 
+  PyErr_SetString: {
+    parameters: ["pointer", "buffer"], // type, message
+    result: "void",
+  },
+
   PyDict_New: {
     parameters: [],
     result: "pointer",


### PR DESCRIPTION
This changes errors like this
```
SystemError: <built-in method JSCallback:anonymous of NoneType object at 0x7f988b6f8bd0> returned NULL without setting an exception
```

To something more useful

```
RuntimeError: JS Callback Error: PythonError: Must be number, not str
```